### PR TITLE
feat(profiler): bump spec references to v2.0 and promote pump tests t…

### DIFF
--- a/apps/profiler/app/components/OgImage/Default.takumi.vue
+++ b/apps/profiler/app/components/OgImage/Default.takumi.vue
@@ -107,7 +107,7 @@ const LOGO_DATA_URI = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAY
       "
     >
       <div style="display: flex;">
-        <span style="color: #0d1218; font-weight: 500; margin-right: 6px;">v1.0</span>
+        <span style="color: #0d1218; font-weight: 500; margin-right: 6px;">v2.0</span>
         <span>{{ badgeSpec || 'spec' }}</span>
       </div>
       <div style="display: flex;">

--- a/apps/profiler/app/pages/index.vue
+++ b/apps/profiler/app/pages/index.vue
@@ -201,7 +201,7 @@ const toolCards = computed(() =>
             class="flex flex-wrap gap-5.5 pt-5 border-t border-surface-200 font-mono text-[11px] text-content-500 tracking-[0.04em]"
           >
             <span
-              ><b class="text-content-0 font-medium">v1.0</b>
+              ><b class="text-content-0 font-medium">v2.0</b>
               {{ t('hero.badgeSpec') }}</span
             >
             <span
@@ -256,7 +256,7 @@ const toolCards = computed(() =>
               >
             </i18n-t>
           </p>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             <LandingPropCard
               v-for="prop in formatProps"
               :key="prop.num"
@@ -431,7 +431,7 @@ const toolCards = computed(() =>
       >
         {{ t('horizon.intro') }}
       </p>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <LandingPropCard
           v-for="prop in horizonProps"
           :key="prop.num"

--- a/apps/profiler/i18n/locales/en.json
+++ b/apps/profiler/i18n/locales/en.json
@@ -25,7 +25,7 @@
   },
   "footer": {
     "version": "welldot · v1.0.0",
-    "spec": ".well spec v1.0",
+    "spec": ".well spec v2.0",
     "license": "Open · Apache 2.0"
   },
   "hero": {
@@ -47,7 +47,7 @@
     "headline1": "One JSON.",
     "headlineEm": "Three",
     "headline2": "purposes.",
-    "intro": "Today, well data lives in PDFs that don't talk to each other. The {well} file is a simple, versioned format to change that — a single JSON that fully describes a well, designed as an {standard}.",
+    "intro": "Today, well data lives in PDFs that don't talk to each other. The {well} file is a simple, versioned format to change that — a single JSON that fully describes a well, from construction and geology to pump tests and maintenance history, designed as an {standard}.",
     "standard": "international standard",
     "props": [
       {
@@ -69,6 +69,16 @@
         "num": "§ 1.4",
         "title": "Open",
         "body": "Human-readable JSON, public specification, and permissive license — free to use, extend, and contribute."
+      },
+      {
+        "num": "§ 1.5",
+        "title": "Pump tests",
+        "body": "Hydrodynamic events and derived aquifer parameters — transmissivity, storativity, specific capacity — recorded as structured time series."
+      },
+      {
+        "num": "§ 1.6",
+        "title": "Operational history",
+        "body": "A dated log of maintenance, inspections, and incidents, with attachments, that follows the well through its working life."
       }
     ]
   },
@@ -131,7 +141,7 @@
     "headline1": "The",
     "headlineEm": "future",
     "headline2": ".",
-    "intro": "v1 covers geological and construction profiles. The specification evolves openly to embrace the full lifecycle of a well.",
+    "intro": "v2 covers geological, construction, and hydrodynamic profiles — pump tests, aquifer analysis, and operational history. The specification evolves openly to embrace what's still ahead.",
     "props": [
       {
         "num": "§ 4.1",
@@ -140,26 +150,16 @@
       },
       {
         "num": "§ 4.2",
-        "title": "Pump tests",
-        "body": "Pump tests, recovery, specific flow, and hydrodynamic parameters as time series."
-      },
-      {
-        "num": "§ 4.3",
-        "title": "Operational history",
-        "body": "Event log: maintenance, pump replacement, static level, shutdowns — dated and attributable."
-      },
-      {
-        "num": "§ 4.4",
         "title": "Water quality",
         "body": "Physical-chemical and bacteriological analyses linked to sampling, depth, and date."
       },
       {
-        "num": "§ 4.5",
+        "num": "§ 4.3",
         "title": "Extended metadata",
         "body": "Water rights, owner, usage regime, cadastral references, and links to regulatory databases."
       },
       {
-        "num": "§ 4.6",
+        "num": "§ 4.4",
         "title": "Community extensions",
         "body": "Namespaces for fields specific to agencies and regions, without breaking the standardized core."
       }

--- a/apps/profiler/i18n/locales/pt.json
+++ b/apps/profiler/i18n/locales/pt.json
@@ -25,7 +25,7 @@
   },
   "footer": {
     "version": "welldot · v1.0.0",
-    "spec": ".well spec v1.0",
+    "spec": ".well spec v2.0",
     "license": "Aberto · Apache 2.0"
   },
   "hero": {
@@ -47,7 +47,7 @@
     "headline1": "Um JSON.",
     "headlineEm": "Três",
     "headline2": "propósitos.",
-    "intro": "Hoje, dados de poços vivem em PDFs que não se conversam entre si. O arquivo {well} é um formato simples e versionado para mudar isso — um único JSON que descreve o poço por inteiro, pensado como {standard}.",
+    "intro": "Hoje, dados de poços vivem em PDFs que não se conversam entre si. O arquivo {well} é um formato simples e versionado para mudar isso — um único JSON que descreve o poço por inteiro, da construção e geologia aos testes de bombeamento e ao histórico de manutenção, pensado como {standard}.",
     "standard": "padrão internacional",
     "props": [
       {
@@ -69,6 +69,16 @@
         "num": "§ 1.4",
         "title": "Aberto",
         "body": "JSON legível por humanos, especificação pública e licença permissiva — livre para usar, estender e contribuir."
+      },
+      {
+        "num": "§ 1.5",
+        "title": "Testes de bombeamento",
+        "body": "Eventos hidrodinâmicos e parâmetros de aquífero derivados — transmissividade, armazenamento, capacidade específica — registrados como séries temporais estruturadas."
+      },
+      {
+        "num": "§ 1.6",
+        "title": "Histórico operacional",
+        "body": "Um log datado de manutenções, inspeções e incidentes, com anexos, que acompanha o poço ao longo de sua vida útil."
       }
     ]
   },
@@ -131,7 +141,7 @@
     "headline1": "O",
     "headlineEm": "futuro",
     "headline2": ".",
-    "intro": "A v1 cobre perfil geológico e construtivo. A especificação evolui de forma aberta para abraçar todo o ciclo de vida de um poço.",
+    "intro": "A v2 cobre perfis geológicos, construtivos e hidrodinâmicos — testes de bombeamento, análise de aquífero e histórico operacional. A especificação evolui de forma aberta para abraçar o que ainda vem pela frente.",
     "props": [
       {
         "num": "§ 4.1",
@@ -140,26 +150,16 @@
       },
       {
         "num": "§ 4.2",
-        "title": "Testes de bombeamento",
-        "body": "Pump tests, recuperação, vazão específica e parâmetros hidrodinâmicos como séries temporais."
-      },
-      {
-        "num": "§ 4.3",
-        "title": "Histórico operacional",
-        "body": "Log de eventos: manutenções, troca de bomba, nível estático, paradas — datados e atribuíveis."
-      },
-      {
-        "num": "§ 4.4",
         "title": "Qualidade da água",
         "body": "Análises físico-químicas e bacteriológicas vinculadas à amostragem, profundidade e data."
       },
       {
-        "num": "§ 4.5",
+        "num": "§ 4.3",
         "title": "Metadados estendidos",
         "body": "Outorga, proprietário, regime de uso, referências cadastrais e vínculos com bases regulatórias."
       },
       {
-        "num": "§ 4.6",
+        "num": "§ 4.4",
         "title": "Extensões da comunidade",
         "body": "Namespaces para campos específicos de órgãos e regiões, sem quebrar o núcleo padronizado."
       }


### PR DESCRIPTION
…o current features

Moves all `.well spec v1.0` badges and version mentions to v2.0, reflects that pump tests and operational history are now current spec features (not roadmap), and rebalances the landing page prop grids accordingly.