### PR TITLE
ci(publish): migrate npm publish workflows to trusted publishing

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -23,8 +23,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +43,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Set pre-release version (preview branch)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
@@ -60,14 +65,10 @@ jobs:
       - name: Publish stable to npm (tag)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: pnpm publish --filter=@welldot/core --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish next to npm (preview branch)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         run: pnpm publish --filter=@welldot/core --no-git-checks --access public --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry run (pack only)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'

--- a/.github/workflows/publish-render.yml
+++ b/.github/workflows/publish-render.yml
@@ -25,8 +25,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +45,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Set pre-release version (preview branch)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
@@ -62,14 +67,10 @@ jobs:
       - name: Publish stable to npm (tag)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: pnpm publish --filter=@welldot/render --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish next to npm (preview branch)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         run: pnpm publish --filter=@welldot/render --no-git-checks --access public --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry run (pack only)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'

--- a/.github/workflows/publish-utils.yml
+++ b/.github/workflows/publish-utils.yml
@@ -24,8 +24,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +44,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Set pre-release version (preview branch)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
@@ -61,14 +66,10 @@ jobs:
       - name: Publish stable to npm (tag)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: pnpm publish --filter=@welldot/utils --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish next to npm (preview branch)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         run: pnpm publish --filter=@welldot/utils --no-git-checks --access public --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry run (pack only)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'


### PR DESCRIPTION
Replaces `NODE_AUTH_TOKEN` secret with OIDC-based trusted publishing across all three package workflows. Adds `id-token: write` permission, pins the job to the `release` environment, and upgrades npm to support provenance/trusted publishing before the publish steps.